### PR TITLE
Fix sysconfig template when public_ip is defined

### DIFF
--- a/templates/sysconfig/flanneld.erb
+++ b/templates/sysconfig/flanneld.erb
@@ -29,7 +29,7 @@ FLANNEL_OPTIONS="<% -%>
  -networks=<%= scope['flannel::networks'] -%>
 <% end -%>
 <% if @public_ip then -%>
- -public-ip="<%= scope['flannel::public_ip'] %>"
+ -public-ip=<%= scope['flannel::public_ip'] -%>
 <% end -%>
 <% if @remote then -%>
  -remote=<%= scope['flannel::remote'] -%>


### PR DESCRIPTION
No need to double quote the IP (esp. since the generated string will be part
of an other double quoted string). Also, prevent a line break. Without those
changes, we end up generating something like that:

	FLANNEL_OPTIONS=" -alsologtostderr=true -ip-masq=false -public-ip="10.120.10.158"
	 -subnet-dir=/run/flannel/networks -subnet-file=/run/flannel/subnet.env"

which prevent flanneld from starting.